### PR TITLE
✨ add lazy dispatch return valure

### DIFF
--- a/packages/react-redux/src/index.spec.ts
+++ b/packages/react-redux/src/index.spec.ts
@@ -1,0 +1,13 @@
+import { exposeThunks } from '@web-ext/redux'
+import { useDispatch } from '.'
+
+const { thunks } = exposeThunks({
+  format: (a: number) => () => String(a),
+})
+
+export const x = async () => {
+  const dispatch = useDispatch()
+
+  const r = dispatch(thunks.format(1))
+  return r
+}

--- a/packages/react-redux/src/index.spec.ts
+++ b/packages/react-redux/src/index.spec.ts
@@ -7,7 +7,8 @@ const { thunks } = exposeThunks({
 
 export const x = async () => {
   const dispatch = useDispatch()
-
-  const r = dispatch(thunks.format(1))
-  return r
+  const action = thunks.format(1)
+  const r1 = await dispatch(action)
+  const r2 = dispatch({ type: 'a' })
+  return r1
 }

--- a/packages/react-redux/src/index.ts
+++ b/packages/react-redux/src/index.ts
@@ -1,17 +1,16 @@
 import type { FC } from 'react'
-import type { Action, AnyAction } from 'redux'
-import type { ForegroundStore } from '@web-ext/redux'
+import type { AnyAction } from 'redux'
+import type { ForegroundStore, ProxyThunkAction } from '@web-ext/redux'
 import { Provider, useDispatch, useSelector } from 'react-redux'
 
-export type AsyncDispatch<A extends Action = AnyAction> = (
-  action: A,
-) => Promise<A>
+interface ProxyDispatch {
+  /** returns a promise of a proxy thunk */
+  <A extends ProxyThunkAction>(action: A): Promise<A['__return__']>
+  /** returns nothing for non-thunk actions */
+  (action: AnyAction): void
+}
 
-export type ForegroundDispatchHook = <
-  A extends Action = AnyAction
->() => AsyncDispatch<A>
-
-const useForegroundDispatch = useDispatch as ForegroundDispatchHook
+const useForegroundDispatch: () => ProxyDispatch = useDispatch
 
 const BackgroundProvider = (Provider as any) as FC<{ store: ForegroundStore }>
 

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -15,7 +15,7 @@
     "access": "public"
   },
   "dependencies": {
-    "nanoid": "^3.1.12",
+    "@reduxjs/toolkit": "^1.4.0",
     "redux": "^4.0.5",
     "webextension-polyfill-ts": "^0.20.0"
   },

--- a/packages/redux/src/background.ts
+++ b/packages/redux/src/background.ts
@@ -21,7 +21,7 @@ const createDispatchListener = (store: Store) => async (
   } catch (e) {
     result = e instanceof Error ? e : new Error(e?.message || e)
   } finally {
-    port.postMessage(createReplyMessage(message.meta, result))
+    if (message.meta) port.postMessage(createReplyMessage(message.meta, result))
   }
 }
 

--- a/packages/redux/src/foreground.spec.ts
+++ b/packages/redux/src/foreground.spec.ts
@@ -1,0 +1,14 @@
+import { exposeThunks } from './thunks'
+import { ForegroundStore } from './foreground'
+
+const { thunks } = exposeThunks({
+  format: (a: number) => () => String(a),
+})
+
+export const x = async () => {
+  const store = new ForegroundStore()
+  const action = thunks.format(1)
+  const r1 = await store.dispatch(action)
+  const r2 = store.dispatch({ type: 'a' })
+  return r1
+}

--- a/packages/redux/src/foreground.ts
+++ b/packages/redux/src/foreground.ts
@@ -1,5 +1,5 @@
 import { browser, Runtime } from 'webextension-polyfill-ts'
-import { nanoid } from 'nanoid'
+import { nanoid } from '@reduxjs/toolkit'
 import { connected, awaiting } from './constants'
 import { createDispatchMessage, isNewStateMesssage } from './messages'
 import { isReplyMessage } from './messages/reply'
@@ -63,7 +63,7 @@ export class ForegroundStore<S = {}> {
   // redux store API (sans observable stuff)
   dispatch<A extends ProxyThunkAction>(action: A): Promise<A['__return__']>
   dispatch<A extends AnyAction>(action: A): void
-  dispatch(action: AnyAction) {
+  dispatch(action: ProxyThunkAction | AnyAction) {
     if (typeof action === 'function') {
       throw new Error('tried to dispatch a bare (non-exposed) thunk')
     }

--- a/packages/redux/src/index.ts
+++ b/packages/redux/src/index.ts
@@ -1,3 +1,5 @@
 export { ForegroundStore } from './foreground'
 export { exposeStore, createWebExtMiddleware } from './background'
 export { exposeThunks } from './thunks'
+
+export type { ProxyThunkAction } from './thunks'

--- a/packages/redux/src/messages/dispatch.ts
+++ b/packages/redux/src/messages/dispatch.ts
@@ -2,12 +2,12 @@ import { dispatch } from '../constants'
 
 type WrappedAction<A extends any = any> = {
   type: typeof dispatch
-  meta: string
+  meta: string | null
   payload: A
 }
 
 export const createDispatchMessage = <A extends any>(
-  dispatchId: string,
+  dispatchId: string | null,
   action: A,
 ): WrappedAction<A> => ({
   type: dispatch,

--- a/packages/redux/src/thenable.ts
+++ b/packages/redux/src/thenable.ts
@@ -1,0 +1,21 @@
+type PromiseArgs = Parameters<ConstructorParameters<PromiseConstructor>[0]>
+type PC = { tracked: boolean; resolve: PromiseArgs[0]; reject: PromiseArgs[1] }
+
+export const createThenable = (callback: (control: PC) => void) => {
+  const control = { tracked: false } as PC
+  const promise = new Promise((resolve, reject) => {
+    Object.assign(control, { resolve, reject })
+  })
+
+  Promise.resolve().then(() => {
+    if (!control.tracked) control.resolve()
+    callback(control)
+  })
+
+  return {
+    then: (...args: PromiseArgs) => {
+      control.tracked = true
+      return promise.then(...args)
+    },
+  }
+}

--- a/packages/redux/src/thunks.ts
+++ b/packages/redux/src/thunks.ts
@@ -1,24 +1,33 @@
 import type { ThunkAction } from 'redux-thunk'
-import { thunk } from './constants'
+import { thunk as type } from './constants'
 
 type AnyThunk = ThunkAction<any, any, any, any>
 type ThunkMap = Record<string, (...args: any[]) => AnyThunk>
+type KeyOfMap = string | symbol | number
+
+export type ProxyThunkAction<
+  A extends any[] = any[],
+  K extends KeyOfMap = KeyOfMap,
+  R extends any = any
+> = {
+  type: typeof type
+  payload: A
+  meta: K
+  __return__: R
+}
 
 type ProxyThunk<M extends ThunkMap, K extends keyof M> = (
   ...args: Parameters<M[K]>
-) => {
-  type: typeof thunk
-  payload: typeof args
-  meta: K
-}
+) => ProxyThunkAction<typeof args, K, ReturnType<ReturnType<M[K]>>>
 
-export const exposeThunks = <M extends ThunkMap>(thunks: M) => {
-  const exposed = {} as { [K in keyof M]: ProxyThunk<M, K> }
-  for (const key in thunks) {
-    exposed[key] = (...args) => ({ type: thunk, payload: args, meta: key })
+export const exposeThunks = <M extends ThunkMap>(thunkMap: M) => {
+  const thunks = {} as { [K in keyof M]: ProxyThunk<M, K> }
+
+  for (const meta in thunkMap) {
+    thunks[meta] = (...payload) => ({ type, payload, meta } as any)
   }
 
-  return { registry: thunks, exposed }
+  return { registry: thunkMap, thunks }
 }
 
 export const isProxyThunkAction = (
@@ -26,7 +35,7 @@ export const isProxyThunkAction = (
 ): input is ReturnType<ProxyThunk<any, any>> => {
   if (!input) return false
   if (typeof input !== 'object') return false
-  if (input.type !== thunk) return false
+  if (input.type !== type) return false
   if (typeof input.meta !== 'string') return false
   if (!Array.isArray(input.payload)) return false
   return true

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,6 +180,16 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@reduxjs/toolkit@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.4.0.tgz#ee2e2384cc3d1d76780d844b9c2da3580d32710d"
+  integrity sha512-hkxQwVx4BNVRsYdxjNF6cAseRmtrkpSlcgJRr3kLUcHPIAMZAmMJkXmHh/eUEGTMqPzsYpJLM7NN2w9fxQDuGw==
+  dependencies:
+    immer "^7.0.3"
+    redux "^4.0.0"
+    redux-thunk "^2.3.0"
+    reselect "^4.0.0"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -1252,6 +1262,11 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
+immer@^7.0.3:
+  version "7.0.14"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.14.tgz#3e605f8584b15a9520d2f2f3fda9441cc9170d25"
+  integrity sha512-BxCs6pJwhgSEUEOZjywW7OA8DXVzfHjkBelSEl0A+nEu0+zS4cFVdNOONvt55N4WOm8Pu4xqSPYxhm1Lv2iBBA==
+
 import-cwd@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-3.0.0.tgz#20845547718015126ea9b3676b7592fb8bd4cf92"
@@ -1766,11 +1781,6 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nanoid@^3.1.12:
-  version "3.1.12"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.12.tgz#6f7736c62e8d39421601e4a0c77623a97ea69654"
-  integrity sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==
-
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
@@ -2266,6 +2276,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
 resolve-alpn@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
fixes dispatch return values:
- `void` for regular actions
- thunk return value, if it's `awaited` synchronously

this avoids useless return messages being sent to the dispatcher.
it makes the typescript types more explicit.